### PR TITLE
fix doctorMissingElements by not using eval

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ var YAMLToJSON ={
   doctorMissingElements:function(doc){
     for(var key in doc){        
       this.keyChain.push(key);
-      var actual = eval("this.refDoc."+this.keyChain.join("."));
-      var comparable = eval("this.comparableDoc."+this.keyChain.join("."));
+      var actual = this["refDoc."+this.keyChain.join(".")];
+      var comparable = this["comparableDoc."+this.keyChain.join(".")];
       var actualType = typeof actual;
       var comparableType = typeof comparable;
       if((actual instanceof Object) && (comparable!=undefined && (actualType==comparableType))){
@@ -66,7 +66,7 @@ var YAMLToJSON ={
       else{
         var actualKey = this.keyChain.join(".");
         if(comparable ==undefined || (actualType != comparableType)){
-          eval("this.comparableDoc."+actualKey+"=this.refDoc."+actualKey);
+          this["comparableDoc."+actualKey] = this["refDoc."+actualKey];
         }
       }        
       this.keyChain.pop();
@@ -78,7 +78,7 @@ var YAMLToJSON ={
     var path = {
         yaml: (params.yamlDir || config.i18n.yamlDir),
         js: (params.jsDir || config.i18n.jsDir),
-	   locale: (params.defaultLocale || config.i18n.defaultLocale)
+        locale: (params.defaultLocale || config.i18n.defaultLocale)
       };
     var JS_PATH_TOKEN = "--js-path=";
     var YAML_PATH_TOKEN = "--yaml-path=";
@@ -90,7 +90,7 @@ var YAMLToJSON ={
       else if(process.argv[i].indexOf(YAML_PATH_TOKEN)!=-1){
         path["yaml"] = process.argv[i].split(YAML_PATH_TOKEN)[1];
       }
-	 else if(process.argv[i].indexOf(DEFAULT_LOCALE_TOKEN)!=-1){
+      else if(process.argv[i].indexOf(DEFAULT_LOCALE_TOKEN)!=-1){
         path["locale"] = process.argv[i].split(DEFAULT_LOCALE_TOKEN)[1];
       }
     }
@@ -99,6 +99,6 @@ var YAMLToJSON ={
 }
 
 module.exports = {
-	name:"ember-i18n-yaml-to-json",
-	engine:YAMLToJSON
+  name:"ember-i18n-yaml-to-json",
+  engine:YAMLToJSON
 };


### PR DESCRIPTION
`doctorMissingElements` fails when the yaml has a numeric/mixed key

example:

```
en:
  whatever:
    1x2: "fails"
```

error:

```
Unexpected number
SyntaxError: Unexpected number
  at Object.YAMLToJSON.doctorMissingElements (node_modules/ember-i18n-yaml-to-json/index.js:59:39)
  at Object.YAMLToJSON.doctorMissingElements (node_modules/ember-i18n-yaml-to-json/index.js:64:14)
  at Object.YAMLToJSON.doctorMissingElements (node_modules/ember-i18n-yaml-to-json/index.js:64:14)
  at Object.YAMLToJSON.convert (node_modules/ember-i18n-yaml-to-json/index.js:29:12)
  at Object.<anonymous> (ember-cli-build.js:5:18)
  at Module._compile (module.js:460:26)
  at Object.Module._extensions..js (module.js:478:10)
  at Module.load (module.js:355:32)
  at Function.Module._load (module.js:310:12)
  at Module.require (module.js:365:17)
  at require (module.js:384:17)
  at module.exports (node_modules/ember-cli/lib/utilities/find-build-file.js:19:19)
  at Class.module.exports.Task.extend.setupBroccoliBuilder (node_modules/ember-cli/lib/models/builder.js:25:21)
  at Class.module.exports.Task.extend.init (node_modules/ember-cli/lib/models/builder.js:50:10)
  at new Class (node_modules/ember-cli/node_modules/core-object/core-object.js:18:12)
  at Class.module.exports.Task.extend.run (node_modules/ember-cli/lib/tasks/serve.js:15:19)
  at Class.<anonymous> (node_modules/ember-cli/lib/commands/serve.js:62:20)
  at lib$rsvp$$internal$$tryCatch (node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:493:16)
  at lib$rsvp$$internal$$invokeCallback (node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:505:17)
  at lib$rsvp$$internal$$publish (node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:476:11)
  at lib$rsvp$asap$$flush (node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1198:9)
  at process._tickCallback (node.js:355:11)
```

also using `eval` is almost never a good idea ;)
